### PR TITLE
Team Gallery title fix

### DIFF
--- a/content/pages/example-gallery.mdx
+++ b/content/pages/example-gallery.mdx
@@ -8,7 +8,7 @@ blocks:
       Board of Directors, Young Professionals Board and Advisory Council below.
     roles:
       - roleName: Staff
-        roleDescription: "Our staff members lead our operations and collaborate with our volunteers to advance our mission to increase access to safe, verified resources for the diverse LGBTQ+ community.\_\n\n*Join us! Learn more about our open staff, volunteer and intern positions [here](https://inreach.org/join-our-team/) (\\*all positions remote).*\n"
+        roleDescription: "# Staff\n\nOur staff members lead our operations and collaborate with our volunteers to advance our mission to increase access to safe, verified resources for the diverse LGBTQ+ community.\_\n\n*Join us! Learn more about our open staff, volunteer and intern positions [here](https://inreach.org/join-our-team/) (\\*all positions remote).*\n"
         employees:
           - image: /people/JSgarro.jpg
             fullName: Jamie Sgarro
@@ -62,3 +62,4 @@ blocks:
         roleDescription: "Our interns join us for the summer or a semester to develop their skills while helping to advance our mission to increase access to safe, verified resources for the diverse LGBTQ+ community.\n\nInterested in interning with us? Click\_[here](https://inreach.org/join-our-team/)\_to view our available internship positions.\n"
     _template: teamGallery
 ---
+

--- a/content/pages/example-gallery.mdx
+++ b/content/pages/example-gallery.mdx
@@ -62,4 +62,3 @@ blocks:
         roleDescription: "Our interns join us for the summer or a semester to develop their skills while helping to advance our mission to increase access to safe, verified resources for the diverse LGBTQ+ community.\n\nInterested in interning with us? Click\_[here](https://inreach.org/join-our-team/)\_to view our available internship positions.\n"
     _template: teamGallery
 ---
-

--- a/content/pages/example-hero.mdx
+++ b/content/pages/example-hero.mdx
@@ -13,4 +13,3 @@ blocks:
       position: Left
     _template: hero
 ---
-

--- a/src/components/blocks/TeamGallery.tsx
+++ b/src/components/blocks/TeamGallery.tsx
@@ -56,7 +56,6 @@ export const TeamGalleryContainer = ({ data }: { data: PageBlocksTeamGallery }) 
 										key={block.roleName + 'Fragment' + z}
 										className='prose prose-stone prose-headings:mb-2 prose-p:mb-2 w-full max-w-none'
 									>
-										<h1 className='uppercase text-3xl font-bold'>{block.roleName}</h1>
 										<TinaMarkdown content={block.roleDescription} />
 									</div>
 								)


### PR DESCRIPTION
## Description
Removed the roleName to be rendered. Instead the user will now add the roleName in the Markdown Box. This was needed to match some of the designs for the intern and volunteers sections of the Gallery.

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/5975d334-76eb-4d7e-a156-5ad00d328e71" />

